### PR TITLE
Update: add setAnonymousIdOnce and clearAnonymousId

### DIFF
--- a/Rudder/RSClient.h
+++ b/Rudder/RSClient.h
@@ -73,6 +73,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void) setAnonymousId: (NSString *__nullable) anonymousId;
 
++ (void) setAnonymousIdOnce:(NSString *__nullable)anonymousId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Rudder/RSClient.m
+++ b/Rudder/RSClient.m
@@ -241,6 +241,7 @@ static RSOption* _defaultOptions = nil;
         [_repository reset];
     }
     
+    // clear anonymous id
     [[RSPreferenceManager getInstance] clearAnonymousId];
 }
 
@@ -281,6 +282,16 @@ static RSOption* _defaultOptions = nil;
 + (void)setAnonymousId:(NSString *)anonymousId {
     RSPreferenceManager *preferenceManager = [RSPreferenceManager getInstance];
     [preferenceManager saveAnonymousId:anonymousId];
+}
+
+/**
+ * Save anonymous id only once
+ * if there's already stored anonymous id, subsequent set will be ignored
+ * If null is inserted, the anonymous id will be set to null.
+ */
++ (void)setAnonymousIdOnce:(NSString *)anonymousId {
+    RSPreferenceManager *preferenceManager = [RSPreferenceManager getInstance];
+    [preferenceManager saveAnonymousIdOnce:anonymousId];
 }
 
 @end

--- a/Rudder/RSClient.m
+++ b/Rudder/RSClient.m
@@ -247,9 +247,6 @@ BOOL _isOptedOut;
     if (_repository != nil) {
         [_repository reset];
     }
-    
-    // clear anonymous id
-    [[RSPreferenceManager getInstance] clearAnonymousId];
 }
 
 - (void)flush {

--- a/Rudder/RSClient.m
+++ b/Rudder/RSClient.m
@@ -240,6 +240,8 @@ static RSOption* _defaultOptions = nil;
     if (_repository != nil) {
         [_repository reset];
     }
+    
+    [[RSPreferenceManager getInstance] clearAnonymousId];
 }
 
 - (void)flush {

--- a/Rudder/RSPreferenceManager.h
+++ b/Rudder/RSPreferenceManager.h
@@ -39,6 +39,7 @@ extern NSString *const RSExternalIdKey;
 
 - (NSString* __nullable) getAnonymousId;
 - (void) saveAnonymousId: (NSString* __nullable) anonymousId;
+- (void) saveAnonymousIdOnce:(NSString * __nullable)anonymousId;
 - (void) clearAnonymousId;
 
 @end

--- a/Rudder/RSPreferenceManager.h
+++ b/Rudder/RSPreferenceManager.h
@@ -39,6 +39,7 @@ extern NSString *const RSExternalIdKey;
 
 - (NSString* __nullable) getAnonymousId;
 - (void) saveAnonymousId: (NSString* __nullable) anonymousId;
+- (void) clearAnonymousId;
 
 @end
 

--- a/Rudder/RSPreferenceManager.m
+++ b/Rudder/RSPreferenceManager.m
@@ -102,7 +102,7 @@ NSString *const RSAnonymousIdKey =  @"rl_anonymous_id";
     NSString *storedKey = [[NSUserDefaults standardUserDefaults] valueForKey:RSAnonymousIdKey];
     
     // if anonymousId has not been set, then set new one
-    // else use existing
+    // else use existing anonymous id
     if (storedKey == nil) {
         [[NSUserDefaults standardUserDefaults] setValue:anonymousId forKey:RSAnonymousIdKey];
         [[NSUserDefaults standardUserDefaults] synchronize];

--- a/Rudder/RSPreferenceManager.m
+++ b/Rudder/RSPreferenceManager.m
@@ -98,4 +98,19 @@ NSString *const RSAnonymousIdKey =  @"rl_anonymous_id";
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
+- (void)saveAnonymousIdOnce:(NSString *)anonymousId {
+    NSString *storedKey = [[NSUserDefaults standardUserDefaults] valueForKey:RSAnonymousIdKey];
+    
+    // if anonymousId has not been set, then set new one
+    // else use existing
+    if (storedKey == nil) {
+        [[NSUserDefaults standardUserDefaults] setValue:anonymousId forKey:RSAnonymousIdKey];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }
+}
+
+- (void)clearAnonymousId {
+    [self saveAnonymousId:nil];
+}
+
 @end


### PR DESCRIPTION
## Overview
RudderStack iOS SDK needs to be adjusted to Feedloop’s requirements [here](https://docs.google.com/document/d/1taNL43Jn6y7lwHljWc9XdZhvrjVkzInwB59tKA_GKsc/edit#)

## Changes

- [x] Introduce `[RSClient setAnonymousIdOnce]`, this will setAnonymousId once, subsequent set will be ignored.

- [x] Add some doc comments

## How to test

Use this example app, follow the instruction on README

https://github.com/mamaz/TestRudder


